### PR TITLE
Pycodestyle - adding tox.ini

### DIFF
--- a/ansible_collections/tox.ini
+++ b/ansible_collections/tox.ini
@@ -1,3 +1,4 @@
 [pycodestyle]
 max-line-length = 160
 ignore = E305,E402,W503,W504,E722,E741
+

--- a/ansible_collections/tox.ini
+++ b/ansible_collections/tox.ini
@@ -1,0 +1,3 @@
+[pycodestyle]
+max-line-length = 160
+ignore = E305,E402,W503,W504,E722,E741


### PR DESCRIPTION
I believe we should provide recommended linter configuration. Adding configuration that is already used by CI checks:

```bash
pycodestyle --max-line-length=160 --ignore=E305,E402,W503,W504,E722,E741
```